### PR TITLE
Be more custom-build friendly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -272,7 +272,7 @@ const poller = (url, status, resolve, reject) => {
     .catch((err) => reject(err));
 };
 
-const UserAgent = {
+export const UserAgent = {
   Desktop: 'Desktop',
   Android: 'Android',
   iOS: 'iOS',
@@ -464,7 +464,7 @@ function startMobileSession(qr, userAgent) {
   }
 }
 
-function detectUserAgent() {
+export function detectUserAgent() {
   if (!browser)
     return null;
 

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ const optionsDefaults = {
 export function handleSession(qr, options = {}) {
   let state = {};
   return setupSession(qr, state, options)
-         .then((p) => finishSession(p, state));
+    .then((p) => finishSession(p, state));
 }
 
 export function setupSession(qr, state, options) {

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,14 @@ const optionsDefaults = {
  * @param {Object} options
  */
 export function handleSession(qr, options = {}) {
-  let state = { qr, done: false };
+  let state = {};
+  return setupSession(qr, state, options)
+         .then((p) => finishSession(p, state));
+}
+
+export function setupSession(qr, state, options) {
+  state.qr = qr;
+  state.done = false;
 
   // When we start the session is always in the Initialized state, but the state at which
   // we return control to the caller depends on the options. See the function comment.
@@ -80,11 +87,15 @@ export function handleSession(qr, options = {}) {
         state.done = true;
         return SessionStatus.Initialized;
       }
-      return waitConnected(state.qr.u);
-    })
 
+      return waitConnected(state.qr.u);
+    });
+}
+
+export function finishSession(status, state) {
+  return Promise.resolve()
     // 2nd phase: phone connected
-    .then((status) => {
+    .then(() => {
       if (state.done) return status;
 
       log('Session state changed', status, state.qr.u);


### PR DESCRIPTION
This PR makes two changes to `irmajs` that _should_ have no impact on existing use:

* Expose `UserAgent` and `detectUserAgent`
* Split the function `handleSession` up in two parts so we can have a resolving Promise when the user scans the QR code

These two changes are needed to wrap this package in a new design (see https://github.com/nuts-foundation/irma-web-glue for how I use them).