### PR TITLE
feat: add command to run eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@privacybydesign/irmajs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3042,7 +3042,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3063,12 +3064,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3083,17 +3086,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3210,7 +3216,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3222,6 +3229,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3236,6 +3244,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3243,12 +3252,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3267,6 +3278,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3347,7 +3359,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3359,6 +3372,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3444,7 +3458,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3480,6 +3495,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3499,6 +3515,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3542,12 +3559,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/irma.node.js",
   "scripts": {
     "develop": "webpack --mode development --watch",
-    "build": "webpack --mode production"
+    "build": "webpack --mode production",
+    "lint": "eslint \"src/**/*.js\""
   },
   "keywords": [],
   "contributors": [

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export const SessionStatus = {
   Timeout    : 'TIMEOUT',     // Session timed out
 };
 
+/* eslint-disable no-console */
 const optionsDefaults = {
   method:            'popup',            // Supported methods: 'popup', 'canvas', 'mobile' (only browser), 'console' (only node), 'url' (both)
   element:           'irmaqr',           // ID of the canvas to draw to if method === 'canvas'
@@ -34,8 +35,9 @@ const optionsDefaults = {
   qrterminalOptions: {},                 // Options to pass to qrcode-terminal.generate
   qrterminalDisplay: console.log,        // Display function for qrcode-terminal
 };
+/* eslint-enable no-console */
 
-var logEnabled = true;
+let logEnabled = true;
 
 /**
  * Change whether or not the irmajs library logs to console.
@@ -55,7 +57,7 @@ export function setLoggingState(enabled) {
  * @param {Object} options
  */
 export function handleSession(qr, options = {}) {
-  let state = {};
+  const state = {};
   return setupSession(qr, state, options)
     .then((p) => finishSession(p, state));
 }
@@ -147,8 +149,8 @@ export function finishSession(status, state) {
         return status;
       }
 
-      let jwtType = state.options.legacyResultJwt ? 'getproof' : 'result-jwt';
-      let endpoint = state.options.resultJwt || state.options.legacyResultJwt ? jwtType : 'result';
+      const jwtType = state.options.legacyResultJwt ? 'getproof' : 'result-jwt';
+      const endpoint = state.options.resultJwt || state.options.legacyResultJwt ? jwtType : 'result';
       return fetchCheck(`${state.options.server}/session/${state.options.token}/${ endpoint }`);
     })
 
@@ -470,16 +472,16 @@ function translatePopupElement(el, id, lang) {
 }
 
 function getTranslatedString(id, lang) {
-  var parts = id.split('.');
-  var res = translations[lang];
-  for (var part in parts) {
+  const parts = id.split('.');
+  let res = translations[lang];
+  for (const part in parts) {
       if (res === undefined) break;
       res = res[parts[part]];
   }
 
   if (res === undefined) {
       res = translations[optionsDefaults.language];
-      for (part in parts) {
+      for (const part in parts) {
           if (res === undefined) break;
           res = res[parts[part]];
       }


### PR DESCRIPTION
This pull request fixes linting errors, mostly using `var` instead of `const` or `let`. This also adds a command to the `package.json` to run eslint from the command line.